### PR TITLE
Fixing mixed up [] and () instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-!(Code for Baltimore)[/docs/img/CfB.png]
+![Code for Baltimore](/docs/img/CfB.png)
 
 # ProjectTemplate
 The project template for Code for Baltimore github projects.  This project will help your project get started by giving you:
@@ -8,7 +8,7 @@ The project template for Code for Baltimore github projects.  This project will 
 * A big thumbs up :thumbsup:
 
 ## Documentation
-We've included a `docs` folder with a template (Tech Spec)[/docs/Tech_Spec.md] and (Best Practices)[/docs/Best_Practices.md] document, though using Github's Wiki capabilities is also a good idea. This will get you started with documenting your project.  Other documents and relevant information that has no other place can live in the `docs` folder.  Replace this paragraph with a brief breakdown of what you've included in your `docs` folder.
+We've included a `docs` folder with a template [Tech Spec](/docs/Tech_Spec.md) and [Best Practices](/docs/Best_Practices.md) document, though using Github's Wiki capabilities is also a good idea. This will get you started with documenting your project.  Other documents and relevant information that has no other place can live in the `docs` folder.  Replace this paragraph with a brief breakdown of what you've included in your `docs` folder.
 
 ## Setup
 What does someone need to do to get started with your project? Do they need to:

--- a/docs/Best_Practices.md
+++ b/docs/Best_Practices.md
@@ -1,5 +1,5 @@
 # Best Practices
-Code for Baltimore projects should be built with the intention of deploying on (Heroku)[https://heroku.com]. For details on Heroku Best Practices see their (developer documentation)[https://devcenter.heroku.com/articles/node-best-practices].
+Code for Baltimore projects should be built with the intention of deploying on [Heroku](https://heroku.com). For details on Heroku Best Practices see their [developer documentation](https://devcenter.heroku.com/articles/node-best-practices).
 
 ## Project Management
 
@@ -39,7 +39,7 @@ Example: Google has openly published style guides for many languages in wide use
 Static code analysis tools should be used when possible, to monitor and improve code quality. This may be integrated in the local development environment, automated repository commit checks, automated CI/CD pipelines, or other steps in the code development process.
 
 ### SonarQube scanning
-Before committing or pushing any code changes those changes should be scanned with SonarQube.  For convenience a `docker-compose` file has been included with this repository to facilitate local scans so that clean code can be checked and pushed before the deployment scans.  See the (README)[/sonarqube/README.md] in the sonarqube folder for more information.
+Before committing or pushing any code changes those changes should be scanned with SonarQube.  For convenience a `docker-compose` file has been included with this repository to facilitate local scans so that clean code can be checked and pushed before the deployment scans.  See the [README](/sonarqube/README.md) in the sonarqube folder for more information.
 
 ## Git and Branching
 

--- a/docs/Tech_Spec.md
+++ b/docs/Tech_Spec.md
@@ -14,9 +14,9 @@ Simply put: what are you _not_ doing with the project at this time? This section
 Now that you've defined what you won't do with this project (at least in the beginning): what are you going to do? What is the minimum functionality required to launch a successful initial product? Define that here!
 
 ## Diorama-rama
-Can you put your project into pictures? Sure you can! We recommend using (draw.io)[https://draw.io] because it's free and you can make pretty diagrams of all sorts like this:
+Can you put your project into pictures? Sure you can! We recommend using [draw.io](https://draw.io) because it's free and you can make pretty diagrams of all sorts like this:
 
-!(draw.io example)[/docs/img/mind-map-with-drawio.png]
+![draw.io example](https://github.com/CodeForBaltimore/ProjectTemplate/blob/master/docs/img/mind-map-with-drawio.png?raw=true)
 
 ## Components
 Break down your project into as many different sections or components as possible. This could include various pages for a web app, or endpoints for an API project just to name a couple of examples. Try to include any wireframes or mock-ups you can to fully illustrate your idea for each piece!

--- a/sonarqube/README.md
+++ b/sonarqube/README.md
@@ -21,4 +21,4 @@ sonar-scanner
 ```
 
 ## Reference
-For more information visit the (Docker Hub)[https://hub.docker.com/_/sonarqube] project page.
+For more information visit the [Docker Hub](https://hub.docker.com/_/sonarqube) project page.


### PR DESCRIPTION
# Description

In my initial commit I mistakenly swapped the use of [] and () in md image and hyperlinks. This corrects that.
